### PR TITLE
Suggested additional optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ test-interpreters: $(INTERPRETERS)
 %: interpreter-%.c
 	$(CC) $(CFLAGS) $< -o $@
 
-pigletvm: pigletvm-rcache.c pigletvm-exec.c
+pigletvm: pigletvm.c pigletvm-rcache.c pigletvm-exec.c
 	$(CC) $(CFLAGS) $^ -o $@
 
-pigletvm-test: pigletvm-rcache.c pigletvm-test.c
+pigletvm-test: pigletvm.c pigletvm-rcache.c pigletvm-test.c
 	$(CC) -g $(CFLAGS) $^ -o $@
 	./pigletvm-test
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ test-interpreters: $(INTERPRETERS)
 %: interpreter-%.c
 	$(CC) $(CFLAGS) $< -o $@
 
-pigletvm: pigletvm.c pigletvm-exec.c
+pigletvm: pigletvm-rcache.c pigletvm-exec.c
 	$(CC) $(CFLAGS) $^ -o $@
 
-pigletvm-test: pigletvm.c pigletvm-test.c
+pigletvm-test: pigletvm-rcache.c pigletvm-test.c
 	$(CC) -g $(CFLAGS) $^ -o $@
 	./pigletvm-test
 

--- a/pigletvm-exec.c
+++ b/pigletvm-exec.c
@@ -132,6 +132,54 @@ static int disassemble(uint8_t *bytecode)
     return EXIT_SUCCESS;
 }
 
+static int run_switch(uint8_t *bytecode)
+{
+    interpret_result res = vm_interpret(bytecode);
+    if (res != SUCCESS) {
+        fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
+        return EXIT_FAILURE;
+    }
+    uint64_t result_value = vm_get_result();
+    printf("Result value: %" PRIu64 "\n", result_value);
+    return EXIT_SUCCESS;
+}
+
+static int run_switch_no_range_check(uint8_t *bytecode)
+{
+    interpret_result res = vm_interpret_no_range_check(bytecode);
+    if (res != SUCCESS) {
+        fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
+        return EXIT_FAILURE;
+    }
+    uint64_t result_value = vm_get_result();
+    printf("Result value: %" PRIu64 "\n", result_value);
+    return EXIT_SUCCESS;
+}
+
+static int run_threaded(uint8_t *bytecode)
+{
+    interpret_result res = vm_interpret_threaded(bytecode);
+    if (res != SUCCESS) {
+        fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
+        return EXIT_FAILURE;
+    }
+    uint64_t result_value = vm_get_result();
+    printf("Result value: %" PRIu64 "\n", result_value);
+    return EXIT_SUCCESS;
+}
+
+static int run_trace(uint8_t *bytecode)
+{
+    interpret_result res = vm_interpret_trace(bytecode);
+    if (res != SUCCESS) {
+        fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
+        return EXIT_FAILURE;
+    }
+    uint64_t result_value = vm_get_result();
+    printf("Result value: %" PRIu64 "\n", result_value);
+    return EXIT_SUCCESS;
+}
+
 static int run_rcache_switch(uint8_t *bytecode)
 {
     interpret_result res = vm_rcache_interpret(bytecode);
@@ -532,6 +580,22 @@ int main(int argc, char *argv[])
         TIMER_DEF(start_time, end_time);
 
         TIMER_START(start_time);
+        res = run_switch(bytecode);
+        TIMER_END(start_time, end_time, "switch code finished");
+
+        TIMER_START(start_time);
+        res = run_switch_no_range_check(bytecode);
+        TIMER_END(start_time, end_time, "switch code (no range check) finished");
+
+        TIMER_START(start_time);
+        res = run_threaded(bytecode);
+        TIMER_END(start_time, end_time, "threaded code finished");
+
+        TIMER_START(start_time);
+        res = run_trace(bytecode);
+        TIMER_END(start_time, end_time, "trace code finished");
+
+        TIMER_START(start_time);
         res = run_rcache_switch(bytecode);
         TIMER_END(start_time, end_time, "switch code (reg cache) finished");
 
@@ -564,6 +628,26 @@ int main(int argc, char *argv[])
         };
 
         TIMER_DEF(start_time, end_time);
+
+        TIMER_START(start_time);
+        for (int i = 0; i < num_iterations; i++)
+            res = run_switch(bytecode);
+        TIMER_END(start_time, end_time, "switch code finished");
+
+        TIMER_START(start_time);
+        for (int i = 0; i < num_iterations; i++)
+            res = run_switch_no_range_check(bytecode);
+        TIMER_END(start_time, end_time, "switch code (no range check) finished");
+
+        TIMER_START(start_time);
+        for (int i = 0; i < num_iterations; i++)
+            res = run_threaded(bytecode);
+        TIMER_END(start_time, end_time, "threaded code finished");
+
+        TIMER_START(start_time);
+        for (int i = 0; i < num_iterations; i++)
+            res = run_trace(bytecode);
+        TIMER_END(start_time, end_time, "trace code finished");
 
         TIMER_START(start_time);
         for (int i = 0; i < num_iterations; i++)

--- a/pigletvm-exec.c
+++ b/pigletvm-exec.c
@@ -132,50 +132,50 @@ static int disassemble(uint8_t *bytecode)
     return EXIT_SUCCESS;
 }
 
-static int run_switch(uint8_t *bytecode)
+static int run_rcache_switch(uint8_t *bytecode)
 {
-    interpret_result res = vm_interpret(bytecode);
+    interpret_result res = vm_rcache_interpret(bytecode);
     if (res != SUCCESS) {
         fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
         return EXIT_FAILURE;
     }
-    uint64_t result_value = vm_get_result();
+    uint64_t result_value = vm_rcache_get_result();
     printf("Result value: %" PRIu64 "\n", result_value);
     return EXIT_SUCCESS;
 }
 
-static int run_switch_no_range_check(uint8_t *bytecode)
+static int run_rcache_switch_no_range_check(uint8_t *bytecode)
 {
-    interpret_result res = vm_interpret_no_range_check(bytecode);
+    interpret_result res = vm_rcache_interpret_no_range_check(bytecode);
     if (res != SUCCESS) {
         fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
         return EXIT_FAILURE;
     }
-    uint64_t result_value = vm_get_result();
+    uint64_t result_value = vm_rcache_get_result();
     printf("Result value: %" PRIu64 "\n", result_value);
     return EXIT_SUCCESS;
 }
 
-static int run_threaded(uint8_t *bytecode)
+static int run_rcache_threaded(uint8_t *bytecode)
 {
-    interpret_result res = vm_interpret_threaded(bytecode);
+    interpret_result res = vm_rcache_interpret_threaded(bytecode);
     if (res != SUCCESS) {
         fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
         return EXIT_FAILURE;
     }
-    uint64_t result_value = vm_get_result();
+    uint64_t result_value = vm_rcache_get_result();
     printf("Result value: %" PRIu64 "\n", result_value);
     return EXIT_SUCCESS;
 }
 
-static int run_trace(uint8_t *bytecode)
+static int run_rcache_trace(uint8_t *bytecode)
 {
-    interpret_result res = vm_interpret_trace(bytecode);
+    interpret_result res = vm_rcache_interpret_trace(bytecode);
     if (res != SUCCESS) {
         fprintf(stderr, "Runtime error: %s\n", error_to_msg[res]);
         return EXIT_FAILURE;
     }
-    uint64_t result_value = vm_get_result();
+    uint64_t result_value = vm_rcache_get_result();
     printf("Result value: %" PRIu64 "\n", result_value);
     return EXIT_SUCCESS;
 }
@@ -532,20 +532,20 @@ int main(int argc, char *argv[])
         TIMER_DEF(start_time, end_time);
 
         TIMER_START(start_time);
-        res = run_switch(bytecode);
-        TIMER_END(start_time, end_time, "switch code finished");
+        res = run_rcache_switch(bytecode);
+        TIMER_END(start_time, end_time, "switch code (reg cache) finished");
 
         TIMER_START(start_time);
-        res = run_switch_no_range_check(bytecode);
-        TIMER_END(start_time, end_time, "switch code (no range check) finished");
+        res = run_rcache_switch_no_range_check(bytecode);
+        TIMER_END(start_time, end_time, "switch code (reg cache) (no range check) finished");
 
         TIMER_START(start_time);
-        res = run_threaded(bytecode);
-        TIMER_END(start_time, end_time, "threaded code finished");
+        res = run_rcache_threaded(bytecode);
+        TIMER_END(start_time, end_time, "threaded code (reg cache) finished");
 
         TIMER_START(start_time);
-        res = run_trace(bytecode);
-        TIMER_END(start_time, end_time, "trace code finished");
+        res = run_rcache_trace(bytecode);
+        TIMER_END(start_time, end_time, "trace code (reg cache) finished");
 
         free(bytecode);
     } else if (0 == strcmp(cmd, "runtimes")) {
@@ -567,23 +567,23 @@ int main(int argc, char *argv[])
 
         TIMER_START(start_time);
         for (int i = 0; i < num_iterations; i++)
-            res = run_switch(bytecode);
-        TIMER_END(start_time, end_time, "switch code finished");
+            res = run_rcache_switch(bytecode);
+        TIMER_END(start_time, end_time, "switch code (reg cache) finished");
 
         TIMER_START(start_time);
         for (int i = 0; i < num_iterations; i++)
-            res = run_switch_no_range_check(bytecode);
-        TIMER_END(start_time, end_time, "switch code (no range check) finished");
+            res = run_rcache_switch_no_range_check(bytecode);
+        TIMER_END(start_time, end_time, "switch code (reg cache) (no range check) finished");
 
         TIMER_START(start_time);
         for (int i = 0; i < num_iterations; i++)
-            res = run_threaded(bytecode);
-        TIMER_END(start_time, end_time, "threaded code finished");
+            res = run_rcache_threaded(bytecode);
+        TIMER_END(start_time, end_time, "threaded code (reg cache) finished");
 
         TIMER_START(start_time);
         for (int i = 0; i < num_iterations; i++)
-            res = run_trace(bytecode);
-        TIMER_END(start_time, end_time, "trace code finished");
+            res = run_rcache_trace(bytecode);
+        TIMER_END(start_time, end_time, "trace code (reg cache) finished");
 
         free(bytecode);
     } else if (0 == strcmp(cmd, "asm")) {

--- a/pigletvm-rcache.c
+++ b/pigletvm-rcache.c
@@ -12,13 +12,13 @@
 #define MEMORY_SIZE 65536
 
 #define LOAD_REGS()                             \
-    register uint8_t *ip = vm.ip;               \
-    register uint64_t *stack_top = vm.stack_top;\
-    register uint64_t acc = vm.acc
+    register uint8_t *ip = vm_rcache.ip;               \
+    register uint64_t *stack_top = vm_rcache.stack_top;\
+    register uint64_t acc = vm_rcache.acc
 #define STORE_REGS()                            \
-    vm.ip = ip;                                 \
-    vm.stack_top = stack_top;                   \
-    vm.acc = acc
+    vm_rcache.ip = ip;                                 \
+    vm_rcache.stack_top = stack_top;                   \
+    vm_rcache.acc = acc
 #define NEXT_OP()                               \
     (*ip++)
 #define NEXT_ARG()                                      \
@@ -34,7 +34,7 @@
 
 
 /*
- * switch or threaded vm
+ * switch or threaded vm_rcache
  * */
 
 static struct {
@@ -53,20 +53,20 @@ static struct {
 
     /* A single register containing the result */
     uint64_t result;
-} vm;
+} vm_rcache;
 
-static void vm_reset(uint8_t *bytecode)
+static void vm_rcache_reset(uint8_t *bytecode)
 {
-    vm = (typeof(vm)) {
+    vm_rcache = (typeof(vm_rcache)) {
         .acc = 0,
-        .stack_top = vm.stack,
+        .stack_top = vm_rcache.stack,
         .ip = bytecode
     };
 }
 
-interpret_result vm_interpret(uint8_t *bytecode)
+interpret_result vm_rcache_interpret(uint8_t *bytecode)
 {
-    vm_reset(bytecode);
+    vm_rcache_reset(bytecode);
 
     LOAD_REGS();
 
@@ -82,14 +82,14 @@ interpret_result vm_interpret(uint8_t *bytecode)
         case OP_LOADI: {
             /* get the argument, use it to get a value onto stack */
             uint16_t addr = NEXT_ARG();
-            uint64_t val = vm.memory[addr];
+            uint64_t val = vm_rcache.memory[addr];
             PUSH(val);
             break;
         }
         case OP_LOADADDI: {
             /* get the argument, add the value from the address to the top of the stack */
             uint16_t addr = NEXT_ARG();
-            uint64_t val = vm.memory[addr];
+            uint64_t val = vm_rcache.memory[addr];
             TOP() += val;
             break;
         }
@@ -97,19 +97,19 @@ interpret_result vm_interpret(uint8_t *bytecode)
             /* get the argument, use it to get a value of the stack into a memory cell */
             uint16_t addr = NEXT_ARG();
             uint64_t val = POP();
-            vm.memory[addr] = val;
+            vm_rcache.memory[addr] = val;
             break;
         }
         case OP_LOAD: {
             /* pop an address, use it to get a value onto stack */
-            TOP() = vm.memory[TOP()];
+            TOP() = vm_rcache.memory[TOP()];
             break;
         }
         case OP_STORE: {
             /* pop a value, pop an adress, put a value into an address */
             uint64_t val = POP();
             uint16_t addr = POP();
-            vm.memory[addr] = val;
+            vm_rcache.memory[addr] = val;
             break;
         }
         case OP_DUP:{
@@ -210,7 +210,7 @@ interpret_result vm_interpret(uint8_t *bytecode)
         case OP_POP_RES: {
             /* Pop the top of the stack, set it as a result value */
             uint64_t res = POP();
-            vm.result = res;
+            vm_rcache.result = res;
             break;
         }
         case OP_DONE: {
@@ -236,9 +236,9 @@ interpret_result vm_interpret(uint8_t *bytecode)
     return ERROR_END_OF_STREAM;
 }
 
-interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
+interpret_result vm_rcache_interpret_no_range_check(uint8_t *bytecode)
 {
-    vm_reset(bytecode);
+    vm_rcache_reset(bytecode);
 
     LOAD_REGS();
 
@@ -254,14 +254,14 @@ interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
         case OP_LOADI: {
             /* get the argument, use it to get a value onto stack */
             uint16_t addr = NEXT_ARG();
-            uint64_t val = vm.memory[addr];
+            uint64_t val = vm_rcache.memory[addr];
             PUSH(val);
             break;
         }
         case OP_LOADADDI: {
             /* get the argument, add the value from the address to the top of the stack */
             uint16_t addr = NEXT_ARG();
-            uint64_t val = vm.memory[addr];
+            uint64_t val = vm_rcache.memory[addr];
             TOP() += val;
             break;
         }
@@ -269,19 +269,19 @@ interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
             /* get the argument, use it to get a value of the stack into a memory cell */
             uint16_t addr = NEXT_ARG();
             uint64_t val = POP();
-            vm.memory[addr] = val;
+            vm_rcache.memory[addr] = val;
             break;
         }
         case OP_LOAD: {
             /* pop an address, use it to get a value onto stack */
-            TOP() = vm.memory[TOP()];
+            TOP() = vm_rcache.memory[TOP()];
             break;
         }
         case OP_STORE: {
             /* pop a value, pop an adress, put a value into an address */
             uint64_t val = POP();
             uint16_t addr = POP();
-            vm.memory[addr] = val;
+            vm_rcache.memory[addr] = val;
             break;
         }
         case OP_DUP:{
@@ -382,7 +382,7 @@ interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
         case OP_POP_RES: {
             /* Pop the top of the stack, set it as a result value */
             uint64_t res = POP();
-            vm.result = res;
+            vm_rcache.result = res;
             break;
         }
         case OP_DONE: {
@@ -408,9 +408,9 @@ interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
     return ERROR_END_OF_STREAM;
 }
 
-interpret_result vm_interpret_threaded(uint8_t *bytecode)
+interpret_result vm_rcache_interpret_threaded(uint8_t *bytecode)
 {
-    vm_reset(bytecode);
+    vm_rcache_reset(bytecode);
 
     LOAD_REGS();
 
@@ -454,14 +454,14 @@ op_pushi: {
 op_loadi: {
     /* get the argument, use it to get a value onto stack */
         uint16_t addr = NEXT_ARG();
-        uint64_t val = vm.memory[addr];
+        uint64_t val = vm_rcache.memory[addr];
         PUSH(val);
         goto *labels[NEXT_OP()];
     }
 op_loadaddi: {
         /* get the argument, add the value from the address to the top of the stack */
         uint16_t addr = NEXT_ARG();
-        uint64_t val = vm.memory[addr];
+        uint64_t val = vm_rcache.memory[addr];
         TOP() += val;
         goto *labels[NEXT_OP()];
     }
@@ -469,19 +469,19 @@ op_storei: {
         /* get the argument, use it to get a value of the stack into a memory cell */
         uint16_t addr = NEXT_ARG();
         uint64_t val = POP();
-        vm.memory[addr] = val;
+        vm_rcache.memory[addr] = val;
         goto *labels[NEXT_OP()];
     }
 op_load: {
         /* pop an address, use it to get a value onto stack */
-        TOP() = vm.memory[TOP()];
+        TOP() = vm_rcache.memory[TOP()];
         goto *labels[NEXT_OP()];
     }
 op_store: {
         /* pop a value, pop an adress, put a value into an address */
         uint64_t val = POP();
         uint16_t addr = POP();
-        vm.memory[addr] = val;
+        vm_rcache.memory[addr] = val;
         goto *labels[NEXT_OP()];
     }
 op_dup:{
@@ -582,7 +582,7 @@ op_greater_or_equali:{
 op_pop_res: {
         /* Pop the top of the stack, set it as a result value */
         uint64_t res = POP();
-        vm.result = res;
+        vm_rcache.result = res;
         goto *labels[NEXT_OP()];
     }
 op_done: {
@@ -603,9 +603,9 @@ end:
 }
 
 
-uint64_t vm_get_result(void)
+uint64_t vm_rcache_get_result(void)
 {
-    return vm.result;
+    return vm_rcache.result;
 }
 
 #undef LOAD_REGS
@@ -618,7 +618,7 @@ uint64_t vm_get_result(void)
 #undef TOP
 
 /*
- * trace-based vm interpreter
+ * trace-based vm_rcache interpreter
  * */
 
 #define POP()                                   \
@@ -630,7 +630,7 @@ uint64_t vm_get_result(void)
 #define NEXT_HANDLER(code, stack_top)                      \
     (((code)++), (code)->handler((code), (stack_top)))
 #define END_TRACE(code, stack_top)              \
-    { vm_trace.stack_top = (stack_top); return; }
+    { vm_rcache_trace.stack_top = (stack_top); return; }
 #define ARG_AT_PC(bytecode, pc)                                         \
     (((uint64_t)(bytecode)[(pc) + 1] << 8) + (bytecode)[(pc) + 2])
 
@@ -664,14 +664,14 @@ static struct {
     /* A single register containing the result */
     uint64_t result;
 
-} vm_trace;
+} vm_rcache_trace;
 
 static void op_abort_handler(scode *code, uint64_t *stack_top)
 {
     (void) code;
 
-    vm_trace.is_running = false;
-    vm_trace.error = ERROR_END_OF_STREAM;
+    vm_rcache_trace.is_running = false;
+    vm_rcache_trace.error = ERROR_END_OF_STREAM;
 
     END_TRACE(code, stack_top);
 }
@@ -686,7 +686,7 @@ static void op_pushi_handler(scode *code, uint64_t *stack_top)
 static void op_loadi_handler(scode *code, uint64_t *stack_top)
 {
     uint64_t addr = code->arg;
-    uint64_t val = vm_trace.memory[addr];
+    uint64_t val = vm_rcache_trace.memory[addr];
     PUSH(val);
 
     NEXT_HANDLER(code, stack_top);
@@ -695,7 +695,7 @@ static void op_loadi_handler(scode *code, uint64_t *stack_top)
 static void op_loadaddi_handler(scode *code, uint64_t *stack_top)
 {
     uint64_t addr = code->arg;
-    uint64_t val = vm_trace.memory[addr];
+    uint64_t val = vm_rcache_trace.memory[addr];
     TOP() += val;
 
     NEXT_HANDLER(code, stack_top);
@@ -705,7 +705,7 @@ static void op_storei_handler(scode *code, uint64_t *stack_top)
 {
     uint16_t addr = code->arg;
     uint64_t val = POP();
-    vm_trace.memory[addr] = val;
+    vm_rcache_trace.memory[addr] = val;
 
     NEXT_HANDLER(code, stack_top);
 }
@@ -713,7 +713,7 @@ static void op_storei_handler(scode *code, uint64_t *stack_top)
 static void op_load_handler(scode *code, uint64_t *stack_top)
 {
     uint16_t addr = POP();
-    uint64_t val = vm_trace.memory[addr];
+    uint64_t val = vm_rcache_trace.memory[addr];
     PUSH(val);
 
     NEXT_HANDLER(code, stack_top);
@@ -724,7 +724,7 @@ static void op_store_handler(scode *code, uint64_t *stack_top)
 {
     uint64_t val = POP();
     uint16_t addr = POP();
-    vm_trace.memory[addr] = val;
+    vm_rcache_trace.memory[addr] = val;
 
     NEXT_HANDLER(code, stack_top);
 }
@@ -774,9 +774,9 @@ static void op_div_handler(scode *code, uint64_t *stack_top)
     if (arg_right != 0) {
         TOP() /= arg_right;
     } else {
-        vm_trace.is_running = false;
-        vm_trace.error = ERROR_DIVISION_BY_ZERO;
-        longjmp(vm_trace.buf, 1);
+        vm_rcache_trace.is_running = false;
+        vm_rcache_trace.error = ERROR_DIVISION_BY_ZERO;
+        longjmp(vm_rcache_trace.buf, 1);
     }
 
     NEXT_HANDLER(code, stack_top);
@@ -793,7 +793,7 @@ static void op_mul_handler(scode *code, uint64_t *stack_top)
 static void op_jump_handler(scode *code, uint64_t *stack_top)
 {
     uint64_t target = code->arg;
-    vm_trace.pc = target;
+    vm_rcache_trace.pc = target;
 
     END_TRACE(code, stack_top);
 }
@@ -802,7 +802,7 @@ static void op_jump_if_true_handler(scode *code, uint64_t *stack_top)
 {
     if (POP()) {
         uint64_t target = code->arg;
-        vm_trace.pc = target;
+        vm_rcache_trace.pc = target;
     }
     END_TRACE(code, stack_top);
 }
@@ -811,7 +811,7 @@ static void op_jump_if_false_handler(scode *code, uint64_t *stack_top)
 {
     if (!POP()) {
         uint64_t target = code->arg;
-        vm_trace.pc =  target;
+        vm_rcache_trace.pc =  target;
     }
     END_TRACE(code, stack_top);
 }
@@ -866,7 +866,7 @@ static void op_greater_or_equali_handler(scode *code, uint64_t *stack_top)
 static void op_pop_res_handler(scode *code, uint64_t *stack_top)
 {
     uint64_t res = POP();
-    vm_trace.result = res;
+    vm_rcache_trace.result = res;
 
     NEXT_HANDLER(code, stack_top);
 }
@@ -875,8 +875,8 @@ static void op_done_handler(scode *code, uint64_t *stack_top)
 {
     (void) code;
 
-    vm_trace.is_running = false;
-    vm_trace.error = SUCCESS;
+    vm_rcache_trace.is_running = false;
+    vm_rcache_trace.error = SUCCESS;
 
     END_TRACE(code, stack_top);
 }
@@ -928,22 +928,22 @@ static const trace_opinfo trace_opcode_to_opinfo[] = {
 
 static void trace_tail_handler(scode *code, uint64_t* stack_top)
 {
-    vm_trace.pc = code->arg;
+    vm_rcache_trace.pc = code->arg;
 
     END_TRACE(code, stack_top);
 }
 
 static void trace_prejump_handler(scode *code, uint64_t* stack_top)
 {
-    vm_trace.pc = code->arg;
+    vm_rcache_trace.pc = code->arg;
 
     NEXT_HANDLER(code, stack_top);
 }
 
 static void trace_compile_handler(scode *trace_head, uint64_t *stack_top)
 {
-    uint8_t *bytecode = vm_trace.bytecode;
-    size_t pc = vm_trace.pc;
+    uint8_t *bytecode = vm_rcache_trace.bytecode;
+    size_t pc = vm_rcache_trace.pc;
     size_t trace_size = 0;
 
     const trace_opinfo *info = &trace_opcode_to_opinfo[bytecode[pc]];
@@ -997,32 +997,32 @@ static void trace_compile_handler(scode *trace_head, uint64_t *stack_top)
     trace_head->handler(trace_head, stack_top);
 }
 
-static void vm_trace_reset(uint8_t *bytecode)
+static void vm_rcache_trace_reset(uint8_t *bytecode)
 {
-    vm_trace = (typeof(vm_trace)) {
-        .stack_top = vm_trace.stack,
+    vm_rcache_trace = (typeof(vm_rcache_trace)) {
+        .stack_top = vm_rcache_trace.stack,
         .bytecode = bytecode,
         .is_running = true
     };
     for (size_t trace_i = 0; trace_i < MAX_CODE_LEN; trace_i++ )
-        vm_trace.trace_cache[trace_i][0].handler = trace_compile_handler;
+        vm_rcache_trace.trace_cache[trace_i][0].handler = trace_compile_handler;
 }
 
-interpret_result vm_interpret_trace(uint8_t *bytecode)
+interpret_result vm_rcache_interpret_trace(uint8_t *bytecode)
 {
-    vm_trace_reset(bytecode);
+    vm_rcache_trace_reset(bytecode);
 
-    if (!setjmp(vm_trace.buf)) {
-        while(vm_trace.is_running) {
-            scode *code = &vm_trace.trace_cache[vm_trace.pc][0];
-            code->handler(code, vm_trace.stack_top);
+    if (!setjmp(vm_rcache_trace.buf)) {
+        while(vm_rcache_trace.is_running) {
+            scode *code = &vm_rcache_trace.trace_cache[vm_rcache_trace.pc][0];
+            code->handler(code, vm_rcache_trace.stack_top);
         }
     }
 
-    return vm_trace.error;
+    return vm_rcache_trace.error;
 }
 
-uint64_t vm_trace_get_result(void)
+uint64_t vm_rcache_trace_get_result(void)
 {
-    return vm_trace.result;
+    return vm_rcache_trace.result;
 }

--- a/pigletvm.c
+++ b/pigletvm.c
@@ -26,11 +26,11 @@
 #define PEEK_ARG()                              \
     ((ip[0] << 8) + ip[1])
 #define POP()                                   \
-    (*(--stack_top))
+    ({ uint64_t tmp = acc; acc = *(--stack_top); tmp; })
 #define PUSH(val)                               \
-    (*stack_top = (val), stack_top++)
+    (*stack_top = acc, stack_top++, acc = (val))
 #define TOP()                                  \
-    (*(stack_top - 1))
+    (acc)
 
 
 /*
@@ -102,9 +102,7 @@ interpret_result vm_interpret(uint8_t *bytecode)
         }
         case OP_LOAD: {
             /* pop an address, use it to get a value onto stack */
-            uint16_t addr = POP();
-            uint64_t val = vm.memory[addr];
-            PUSH(val);
+            TOP() = vm.memory[TOP()];
             break;
         }
         case OP_STORE: {
@@ -276,9 +274,7 @@ interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
         }
         case OP_LOAD: {
             /* pop an address, use it to get a value onto stack */
-            uint16_t addr = POP();
-            uint64_t val = vm.memory[addr];
-            PUSH(val);
+            TOP() = vm.memory[TOP()];
             break;
         }
         case OP_STORE: {
@@ -478,9 +474,7 @@ op_storei: {
     }
 op_load: {
         /* pop an address, use it to get a value onto stack */
-        uint16_t addr = POP();
-        uint64_t val = vm.memory[addr];
-        PUSH(val);
+        TOP() = vm.memory[TOP()];
         goto *labels[NEXT_OP()];
     }
 op_store: {

--- a/pigletvm.c
+++ b/pigletvm.c
@@ -625,10 +625,8 @@ uint64_t vm_get_result(void)
     (*(--vm_trace.stack_top))
 #define PUSH(val)                               \
     (*vm_trace.stack_top = (val), vm_trace.stack_top++)
-#define PEEK()                                  \
+#define TOP()                                   \
     (*(vm_trace.stack_top - 1))
-#define TOS_PTR()                               \
-    (vm_trace.stack_top - 1)
 #define NEXT_HANDLER(code)                      \
     (((code)++), (code)->handler((code)))
 #define ARG_AT_PC(bytecode, pc)                                         \
@@ -694,7 +692,7 @@ static void op_loadaddi_handler(scode *code)
 {
     uint64_t addr = code->arg;
     uint64_t val = vm_trace.memory[addr];
-    *TOS_PTR() += val;
+    TOP() += val;
 
     NEXT_HANDLER(code);
 }
@@ -729,7 +727,7 @@ static void op_store_handler(scode *code)
 
 static void op_dup_handler(scode *code)
 {
-    PUSH(PEEK());
+    PUSH(TOP());
 
     NEXT_HANDLER(code);
 }
@@ -744,7 +742,7 @@ static void op_discard_handler(scode *code)
 static void op_add_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() += arg_right;
+    TOP() += arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -752,7 +750,7 @@ static void op_add_handler(scode *code)
 static void op_addi_handler(scode *code)
 {
     uint16_t arg_right = code->arg;
-    *TOS_PTR() += arg_right;
+    TOP() += arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -760,7 +758,7 @@ static void op_addi_handler(scode *code)
 static void op_sub_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() -= arg_right;
+    TOP() -= arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -770,7 +768,7 @@ static void op_div_handler(scode *code)
     uint64_t arg_right = POP();
     /* Don't forget to handle the div by zero error */
     if (arg_right != 0) {
-        *TOS_PTR() /= arg_right;
+        TOP() /= arg_right;
     } else {
         vm_trace.is_running = false;
         vm_trace.error = ERROR_DIVISION_BY_ZERO;
@@ -783,7 +781,7 @@ static void op_div_handler(scode *code)
 static void op_mul_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() *= arg_right;
+    TOP() *= arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -815,7 +813,7 @@ static void op_jump_if_false_handler(scode *code)
 static void op_equal_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() = PEEK() == arg_right;
+    TOP() = TOP() == arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -823,7 +821,7 @@ static void op_equal_handler(scode *code)
 static void op_less_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() = PEEK() < arg_right;
+    TOP() = TOP() < arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -831,14 +829,14 @@ static void op_less_handler(scode *code)
 static void op_less_or_equal_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() = PEEK() <= arg_right;
+    TOP() = TOP() <= arg_right;
 
     NEXT_HANDLER(code);
 }
 static void op_greater_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() = PEEK() > arg_right;
+    TOP() = TOP() > arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -846,7 +844,7 @@ static void op_greater_handler(scode *code)
 static void op_greater_or_equal_handler(scode *code)
 {
     uint64_t arg_right = POP();
-    *TOS_PTR() = PEEK() >= arg_right;
+    TOP() = TOP() >= arg_right;
 
     NEXT_HANDLER(code);
 }
@@ -854,7 +852,7 @@ static void op_greater_or_equal_handler(scode *code)
 static void op_greater_or_equali_handler(scode *code)
 {
     uint64_t arg_right = code->arg;
-    *TOS_PTR() = PEEK() >= arg_right;
+    TOP() = TOP() >= arg_right;
 
     NEXT_HANDLER(code);
 }

--- a/pigletvm.c
+++ b/pigletvm.c
@@ -1,0 +1,993 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <setjmp.h>
+
+#include "pigletvm.h"
+
+#define MAX_TRACE_LEN 16
+#define STACK_MAX 256
+#define MEMORY_SIZE 65536
+
+#define NEXT_OP()                               \
+    (*vm.ip++)
+#define NEXT_ARG()                                      \
+    ((void)(vm.ip += 2), (vm.ip[-2] << 8) + vm.ip[-1])
+#define PEEK_ARG()                              \
+    ((vm.ip[0] << 8) + vm.ip[1])
+#define POP()                                   \
+    (*(--vm.stack_top))
+#define PUSH(val)                               \
+    (*vm.stack_top = (val), vm.stack_top++)
+#define PEEK()                                  \
+    (*(vm.stack_top - 1))
+#define TOS_PTR()                               \
+    (vm.stack_top - 1)
+
+
+/*
+ * switch or threaded vm
+ * */
+
+static struct {
+    /* Current instruction pointer */
+    uint8_t *ip;
+
+    /* Fixed-size stack */
+    uint64_t stack[STACK_MAX];
+    uint64_t *stack_top;
+
+    /* Operational memory */
+    uint64_t memory[MEMORY_SIZE];
+
+    /* A single register containing the result */
+    uint64_t result;
+} vm;
+
+static void vm_reset(uint8_t *bytecode)
+{
+    vm = (typeof(vm)) {
+        .stack_top = vm.stack,
+        .ip = bytecode
+    };
+}
+
+interpret_result vm_interpret(uint8_t *bytecode)
+{
+    vm_reset(bytecode);
+
+    for (;;) {
+        uint8_t instruction = NEXT_OP();
+        switch (instruction) {
+        case OP_PUSHI: {
+            /* get the argument, push it onto stack */
+            uint16_t arg = NEXT_ARG();
+            PUSH(arg);
+            break;
+        }
+        case OP_LOADI: {
+            /* get the argument, use it to get a value onto stack */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = vm.memory[addr];
+            PUSH(val);
+            break;
+        }
+        case OP_LOADADDI: {
+            /* get the argument, add the value from the address to the top of the stack */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = vm.memory[addr];
+            *TOS_PTR() += val;
+            break;
+        }
+        case OP_STOREI: {
+            /* get the argument, use it to get a value of the stack into a memory cell */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = POP();
+            vm.memory[addr] = val;
+            break;
+        }
+        case OP_LOAD: {
+            /* pop an address, use it to get a value onto stack */
+            uint16_t addr = POP();
+            uint64_t val = vm.memory[addr];
+            PUSH(val);
+            break;
+        }
+        case OP_STORE: {
+            /* pop a value, pop an adress, put a value into an address */
+            uint64_t val = POP();
+            uint16_t addr = POP();
+            vm.memory[addr] = val;
+            break;
+        }
+        case OP_DUP:{
+            /* duplicate the top of the stack */
+            PUSH(PEEK());
+            break;
+        }
+        case OP_DISCARD: {
+            /* discard the top of the stack */
+            (void)POP();
+            break;
+        }
+        case OP_ADD: {
+            /* Pop 2 values, add 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() += arg_right;
+            break;
+        }
+        case OP_ADDI: {
+            /* Add immediate value to the top of the stack */
+            uint16_t arg_right = NEXT_ARG();
+            *TOS_PTR() += arg_right;
+            break;
+        }
+        case OP_SUB: {
+            /* Pop 2 values, subtract 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() -= arg_right;
+            break;
+        }
+        case OP_DIV: {
+            /* Pop 2 values, divide 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            /* Don't forget to handle the div by zero error */
+            if (arg_right == 0)
+                return ERROR_DIVISION_BY_ZERO;
+            *TOS_PTR() /= arg_right;
+            break;
+        }
+        case OP_MUL: {
+            /* Pop 2 values, multiply 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() *= arg_right;
+            break;
+        }
+        case OP_JUMP:{
+            /* Use arg as a jump target  */
+            uint16_t target = PEEK_ARG();
+            vm.ip = bytecode + target;
+            break;
+        }
+        case OP_JUMP_IF_TRUE:{
+            /* Use arg as a jump target  */
+            uint16_t target = NEXT_ARG();
+            if (POP())
+                vm.ip = bytecode + target;
+            break;
+        }
+        case OP_JUMP_IF_FALSE:{
+            /* Use arg as a jump target  */
+            uint16_t target = NEXT_ARG();
+            if (!POP())
+                vm.ip = bytecode + target;
+            break;
+        }
+        case OP_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() == arg_right;
+            break;
+        }
+        case OP_LESS:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() < arg_right;
+            break;
+        }
+        case OP_LESS_OR_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() <= arg_right;
+            break;
+        }
+        case OP_GREATER:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() > arg_right;
+            break;
+        }
+        case OP_GREATER_OR_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() >= arg_right;
+            break;
+        }
+        case OP_GREATER_OR_EQUALI:{
+            uint64_t arg_right = NEXT_ARG();
+            *TOS_PTR() = PEEK() >= arg_right;
+            break;
+        }
+        case OP_POP_RES: {
+            /* Pop the top of the stack, set it as a result value */
+            uint64_t res = POP();
+            vm.result = res;
+            break;
+        }
+        case OP_DONE: {
+            return SUCCESS;
+        }
+        case OP_PRINT:{
+            uint64_t arg = POP();
+            printf("%" PRIu64 "\n", arg);
+            break;
+        }
+        case OP_ABORT: {
+            return ERROR_END_OF_STREAM;
+        }
+        default:
+            return ERROR_UNKNOWN_OPCODE;
+        }
+    }
+
+    return ERROR_END_OF_STREAM;
+}
+
+interpret_result vm_interpret_no_range_check(uint8_t *bytecode)
+{
+    vm_reset(bytecode);
+
+    for (;;) {
+        uint8_t instruction = NEXT_OP();
+        switch (instruction & 0x1f) {
+        case OP_PUSHI: {
+            /* get the argument, push it onto stack */
+            uint16_t arg = NEXT_ARG();
+            PUSH(arg);
+            break;
+        }
+        case OP_LOADI: {
+            /* get the argument, use it to get a value onto stack */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = vm.memory[addr];
+            PUSH(val);
+            break;
+        }
+        case OP_LOADADDI: {
+            /* get the argument, add the value from the address to the top of the stack */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = vm.memory[addr];
+            *TOS_PTR() += val;
+            break;
+        }
+        case OP_STOREI: {
+            /* get the argument, use it to get a value of the stack into a memory cell */
+            uint16_t addr = NEXT_ARG();
+            uint64_t val = POP();
+            vm.memory[addr] = val;
+            break;
+        }
+        case OP_LOAD: {
+            /* pop an address, use it to get a value onto stack */
+            uint16_t addr = POP();
+            uint64_t val = vm.memory[addr];
+            PUSH(val);
+            break;
+        }
+        case OP_STORE: {
+            /* pop a value, pop an adress, put a value into an address */
+            uint64_t val = POP();
+            uint16_t addr = POP();
+            vm.memory[addr] = val;
+            break;
+        }
+        case OP_DUP:{
+            /* duplicate the top of the stack */
+            PUSH(PEEK());
+            break;
+        }
+        case OP_DISCARD: {
+            /* discard the top of the stack */
+            (void)POP();
+            break;
+        }
+        case OP_ADD: {
+            /* Pop 2 values, add 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() += arg_right;
+            break;
+        }
+        case OP_ADDI: {
+            /* Add immediate value to the top of the stack */
+            uint16_t arg_right = NEXT_ARG();
+            *TOS_PTR() += arg_right;
+            break;
+        }
+        case OP_SUB: {
+            /* Pop 2 values, subtract 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() -= arg_right;
+            break;
+        }
+        case OP_DIV: {
+            /* Pop 2 values, divide 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            /* Don't forget to handle the div by zero error */
+            if (arg_right == 0)
+                return ERROR_DIVISION_BY_ZERO;
+            *TOS_PTR() /= arg_right;
+            break;
+        }
+        case OP_MUL: {
+            /* Pop 2 values, multiply 'em, push the result back to the stack */
+            uint64_t arg_right = POP();
+            *TOS_PTR() *= arg_right;
+            break;
+        }
+        case OP_JUMP:{
+            /* Use arg as a jump target  */
+            uint16_t target = PEEK_ARG();
+            vm.ip = bytecode + target;
+            break;
+        }
+        case OP_JUMP_IF_TRUE:{
+            /* Use arg as a jump target  */
+            uint16_t target = NEXT_ARG();
+            if (POP())
+                vm.ip = bytecode + target;
+            break;
+        }
+        case OP_JUMP_IF_FALSE:{
+            /* Use arg as a jump target  */
+            uint16_t target = NEXT_ARG();
+            if (!POP())
+                vm.ip = bytecode + target;
+            break;
+        }
+        case OP_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() == arg_right;
+            break;
+        }
+        case OP_LESS:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() < arg_right;
+            break;
+        }
+        case OP_LESS_OR_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() <= arg_right;
+            break;
+        }
+        case OP_GREATER:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() > arg_right;
+            break;
+        }
+        case OP_GREATER_OR_EQUAL:{
+            uint64_t arg_right = POP();
+            *TOS_PTR() = PEEK() >= arg_right;
+            break;
+        }
+        case OP_GREATER_OR_EQUALI:{
+            uint64_t arg_right = NEXT_ARG();
+            *TOS_PTR() = PEEK() >= arg_right;
+            break;
+        }
+        case OP_POP_RES: {
+            /* Pop the top of the stack, set it as a result value */
+            uint64_t res = POP();
+            vm.result = res;
+            break;
+        }
+        case OP_DONE: {
+            return SUCCESS;
+        }
+        case OP_PRINT:{
+            uint64_t arg = POP();
+            printf("%" PRIu64 "\n", arg);
+            break;
+        }
+        case OP_ABORT: {
+            return ERROR_END_OF_STREAM;
+        }
+        case 26 ... 0x1f:
+            return ERROR_UNKNOWN_OPCODE;
+        }
+    }
+
+    return ERROR_END_OF_STREAM;
+}
+
+interpret_result vm_interpret_threaded(uint8_t *bytecode)
+{
+    vm_reset(bytecode);
+
+    const void *labels[] = {
+        [OP_PUSHI] = &&op_pushi,
+        [OP_LOADI] = &&op_loadi,
+        [OP_LOADADDI] = &&op_loadaddi,
+        [OP_STORE] = &&op_store,
+        [OP_STOREI] = &&op_storei,
+        [OP_LOAD] = &&op_load,
+        [OP_DUP] = &&op_dup,
+        [OP_DISCARD] = &&op_discard,
+        [OP_ADD] = &&op_add,
+        [OP_ADDI] = &&op_addi,
+        [OP_SUB] = &&op_sub,
+        [OP_DIV] = &&op_div,
+        [OP_MUL] = &&op_mul,
+        [OP_JUMP] = &&op_jump,
+        [OP_JUMP_IF_TRUE] = &&op_jump_if_true,
+        [OP_JUMP_IF_FALSE] = &&op_jump_if_false,
+        [OP_EQUAL] = &&op_equal,
+        [OP_LESS] = &&op_less,
+        [OP_LESS_OR_EQUAL] = &&op_less_or_equal,
+        [OP_GREATER] = &&op_greater,
+        [OP_GREATER_OR_EQUAL] = &&op_greater_or_equal,
+        [OP_GREATER_OR_EQUALI] = &&op_greater_or_equali,
+        [OP_POP_RES] = &&op_pop_res,
+        [OP_DONE] = &&op_done,
+        [OP_PRINT] = &&op_print,
+        [OP_ABORT] = &&op_abort,
+    };
+
+    goto *labels[NEXT_OP()];
+
+op_pushi: {
+        /* get the argument, push it onto stack */
+        uint16_t arg = NEXT_ARG();
+        PUSH(arg);
+        goto *labels[NEXT_OP()];
+    }
+op_loadi: {
+    /* get the argument, use it to get a value onto stack */
+        uint16_t addr = NEXT_ARG();
+        uint64_t val = vm.memory[addr];
+        PUSH(val);
+        goto *labels[NEXT_OP()];
+    }
+op_loadaddi: {
+        /* get the argument, add the value from the address to the top of the stack */
+        uint16_t addr = NEXT_ARG();
+        uint64_t val = vm.memory[addr];
+        *TOS_PTR() += val;
+        goto *labels[NEXT_OP()];
+    }
+op_storei: {
+        /* get the argument, use it to get a value of the stack into a memory cell */
+        uint16_t addr = NEXT_ARG();
+        uint64_t val = POP();
+        vm.memory[addr] = val;
+        goto *labels[NEXT_OP()];
+    }
+op_load: {
+        /* pop an address, use it to get a value onto stack */
+        uint16_t addr = POP();
+        uint64_t val = vm.memory[addr];
+        PUSH(val);
+        goto *labels[NEXT_OP()];
+    }
+op_store: {
+        /* pop a value, pop an adress, put a value into an address */
+        uint64_t val = POP();
+        uint16_t addr = POP();
+        vm.memory[addr] = val;
+        goto *labels[NEXT_OP()];
+    }
+op_dup:{
+        /* duplicate the top of the stack */
+        PUSH(PEEK());
+        goto *labels[NEXT_OP()];
+    }
+op_discard: {
+        /* discard the top of the stack */
+        (void)POP();
+        goto *labels[NEXT_OP()];
+    }
+op_add: {
+        /* Pop 2 values, add 'em, push the result back to the stack */
+        uint64_t arg_right = POP();
+        *TOS_PTR() += arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_addi: {
+        /* Add immediate value to the top of the stack */
+        uint16_t arg_right = NEXT_ARG();
+        *TOS_PTR() += arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_sub: {
+        /* Pop 2 values, subtract 'em, push the result back to the stack */
+        uint64_t arg_right = POP();
+        *TOS_PTR() -= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_div: {
+        /* Pop 2 values, divide 'em, push the result back to the stack */
+        uint64_t arg_right = POP();
+        /* Don't forget to handle the div by zero error */
+        if (arg_right == 0)
+            return ERROR_DIVISION_BY_ZERO;
+        *TOS_PTR() /= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_mul: {
+        /* Pop 2 values, multiply 'em, push the result back to the stack */
+        uint64_t arg_right = POP();
+        *TOS_PTR() *= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_jump:{
+        /* Use arg as a jump target  */
+        uint16_t target = PEEK_ARG();
+        vm.ip = bytecode + target;
+        goto *labels[NEXT_OP()];
+    }
+op_jump_if_true:{
+        /* Use arg as a jump target  */
+        uint16_t target = NEXT_ARG();
+        if (POP())
+            vm.ip = bytecode + target;
+        goto *labels[NEXT_OP()];
+    }
+op_jump_if_false:{
+        /* Use arg as a jump target  */
+        uint16_t target = NEXT_ARG();
+        if (!POP())
+            vm.ip = bytecode + target;
+        goto *labels[NEXT_OP()];
+    }
+op_equal:{
+        uint64_t arg_right = POP();
+        *TOS_PTR() = PEEK() == arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_less:{
+        uint64_t arg_right = POP();
+        *TOS_PTR() = PEEK() < arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_less_or_equal:{
+        uint64_t arg_right = POP();
+        *TOS_PTR() = PEEK() <= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_greater:{
+        uint64_t arg_right = POP();
+        *TOS_PTR() = PEEK() > arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_greater_or_equal:{
+        uint64_t arg_right = POP();
+        *TOS_PTR() = PEEK() >= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_greater_or_equali:{
+        uint64_t arg_right = NEXT_ARG();
+        *TOS_PTR() = PEEK() >= arg_right;
+        goto *labels[NEXT_OP()];
+    }
+op_pop_res: {
+        /* Pop the top of the stack, set it as a result value */
+        uint64_t res = POP();
+        vm.result = res;
+        goto *labels[NEXT_OP()];
+    }
+op_done: {
+        goto end;
+    }
+op_print:{
+        uint64_t arg = POP();
+        printf("%" PRIu64 "\n", arg);
+        goto *labels[NEXT_OP()];
+    }
+op_abort: {
+        return ERROR_END_OF_STREAM;
+    }
+end:
+    return SUCCESS;
+}
+
+
+uint64_t vm_get_result(void)
+{
+    return vm.result;
+}
+
+#undef NEXT_OP
+#undef NEXT_ARG
+#undef PEEK_ARG
+#undef POP
+#undef PUSH
+#undef PEEK
+#undef TOS_PTR
+
+/*
+ * trace-based vm interpreter
+ * */
+
+#define POP()                                   \
+    (*(--vm_trace.stack_top))
+#define PUSH(val)                               \
+    (*vm_trace.stack_top = (val), vm_trace.stack_top++)
+#define PEEK()                                  \
+    (*(vm_trace.stack_top - 1))
+#define TOS_PTR()                               \
+    (vm_trace.stack_top - 1)
+#define NEXT_HANDLER(code)                      \
+    (((code)++), (code)->handler((code)))
+#define ARG_AT_PC(bytecode, pc)                                         \
+    (((uint64_t)(bytecode)[(pc) + 1] << 8) + (bytecode)[(pc) + 2])
+
+typedef struct scode scode;
+
+typedef void trace_op_handler(scode *code);
+
+struct scode {
+    uint64_t arg;
+    trace_op_handler *handler;
+};
+
+typedef scode trace[MAX_TRACE_LEN];
+
+static struct {
+    uint8_t *bytecode;
+    size_t pc;
+    jmp_buf buf;
+    bool is_running;
+    interpret_result error;
+
+    trace trace_cache[MAX_CODE_LEN];
+
+    /* Fixed-size stack */
+    uint64_t stack[STACK_MAX];
+    uint64_t *stack_top;
+
+    /* Operational memory */
+    uint64_t memory[MEMORY_SIZE];
+
+    /* A single register containing the result */
+    uint64_t result;
+
+} vm_trace;
+
+static void op_abort_handler(scode *code)
+{
+    (void) code;
+
+    vm_trace.is_running = false;
+    vm_trace.error = ERROR_END_OF_STREAM;
+}
+
+static void op_pushi_handler(scode *code)
+{
+    PUSH(code->arg);
+
+    NEXT_HANDLER(code);
+}
+
+static void op_loadi_handler(scode *code)
+{
+    uint64_t addr = code->arg;
+    uint64_t val = vm_trace.memory[addr];
+    PUSH(val);
+
+    NEXT_HANDLER(code);
+}
+
+static void op_loadaddi_handler(scode *code)
+{
+    uint64_t addr = code->arg;
+    uint64_t val = vm_trace.memory[addr];
+    *TOS_PTR() += val;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_storei_handler(scode *code)
+{
+    uint16_t addr = code->arg;
+    uint64_t val = POP();
+    vm_trace.memory[addr] = val;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_load_handler(scode *code)
+{
+    uint16_t addr = POP();
+    uint64_t val = vm_trace.memory[addr];
+    PUSH(val);
+
+    NEXT_HANDLER(code);
+
+}
+
+static void op_store_handler(scode *code)
+{
+    uint64_t val = POP();
+    uint16_t addr = POP();
+    vm_trace.memory[addr] = val;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_dup_handler(scode *code)
+{
+    PUSH(PEEK());
+
+    NEXT_HANDLER(code);
+}
+
+static void op_discard_handler(scode *code)
+{
+    (void) POP();
+
+    NEXT_HANDLER(code);
+}
+
+static void op_add_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() += arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_addi_handler(scode *code)
+{
+    uint16_t arg_right = code->arg;
+    *TOS_PTR() += arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_sub_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() -= arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_div_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    /* Don't forget to handle the div by zero error */
+    if (arg_right != 0) {
+        *TOS_PTR() /= arg_right;
+    } else {
+        vm_trace.is_running = false;
+        vm_trace.error = ERROR_DIVISION_BY_ZERO;
+        longjmp(vm_trace.buf, 1);
+    }
+
+    NEXT_HANDLER(code);
+}
+
+static void op_mul_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() *= arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_jump_handler(scode *code)
+{
+    uint64_t target = code->arg;
+    vm_trace.pc = target;
+}
+
+static void op_jump_if_true_handler(scode *code)
+{
+    if (POP()) {
+        uint64_t target = code->arg;
+        vm_trace.pc = target;
+        return;
+    }
+}
+
+static void op_jump_if_false_handler(scode *code)
+{
+    if (!POP()) {
+        uint64_t target = code->arg;
+        vm_trace.pc =  target;
+        return;
+    }
+}
+
+static void op_equal_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() = PEEK() == arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_less_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() = PEEK() < arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_less_or_equal_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() = PEEK() <= arg_right;
+
+    NEXT_HANDLER(code);
+}
+static void op_greater_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() = PEEK() > arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_greater_or_equal_handler(scode *code)
+{
+    uint64_t arg_right = POP();
+    *TOS_PTR() = PEEK() >= arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_greater_or_equali_handler(scode *code)
+{
+    uint64_t arg_right = code->arg;
+    *TOS_PTR() = PEEK() >= arg_right;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_pop_res_handler(scode *code)
+{
+    uint64_t res = POP();
+    vm_trace.result = res;
+
+    NEXT_HANDLER(code);
+}
+
+static void op_done_handler(scode *code)
+{
+    (void) code;
+
+    vm_trace.is_running = false;
+    vm_trace.error = SUCCESS;
+}
+
+static void op_print_handler(scode *code)
+{
+    uint64_t arg = POP();
+    printf("%" PRIu64 "\n", arg);
+
+    NEXT_HANDLER(code);
+}
+
+typedef struct trace_opinfo {
+    bool has_arg;
+    bool is_branch;
+    bool is_abs_jump;
+    bool is_final;
+    trace_op_handler *handler;
+} trace_opinfo;
+
+static const trace_opinfo trace_opcode_to_opinfo[] = {
+    [OP_ABORT] = {false, false, false, true, op_abort_handler},
+    [OP_PUSHI] = {true, false, false, false, op_pushi_handler},
+    [OP_LOADI] = {true, false, false, false, op_loadi_handler},
+    [OP_LOADADDI] = {true, false, false, false, op_loadaddi_handler},
+    [OP_STOREI] = {true, false, false, false, op_storei_handler},
+    [OP_LOAD] = {false, false, false, false, op_load_handler},
+    [OP_STORE] = {false, false, false, false, op_store_handler},
+    [OP_DUP] = {false, false, false, false, op_dup_handler},
+    [OP_DISCARD] = {false, false, false, false, op_discard_handler},
+    [OP_ADD] = {false, false, false, false, op_add_handler},
+    [OP_ADDI] = {true, false, false, false, op_addi_handler},
+    [OP_SUB] = {false, false, false, false, op_sub_handler},
+    [OP_DIV] = {false, false, false, false, op_div_handler},
+    [OP_MUL] = {false, false, false, false, op_mul_handler},
+    [OP_JUMP] = {true, false, true, false, op_jump_handler},
+    [OP_JUMP_IF_TRUE] = {true, true, false, false, op_jump_if_true_handler},
+    [OP_JUMP_IF_FALSE] = {true, true, false, false, op_jump_if_false_handler},
+    [OP_EQUAL] = {false, false, false, false, op_equal_handler},
+    [OP_LESS] = {false, false, false, false, op_less_handler},
+    [OP_LESS_OR_EQUAL] = {false, false, false, false, op_less_or_equal_handler},
+    [OP_GREATER] = {false, false, false, false, op_greater_handler},
+    [OP_GREATER_OR_EQUAL] = {false, false, false, false, op_greater_or_equal_handler},
+    [OP_GREATER_OR_EQUALI] = {true, false, false, false, op_greater_or_equali_handler},
+    [OP_POP_RES] = {false, false, false, false, op_pop_res_handler},
+    [OP_DONE] = {false, false, false, true, op_done_handler},
+    [OP_PRINT] = {false, false, false, false, op_print_handler},
+};
+
+static void trace_tail_handler(scode *code)
+{
+    vm_trace.pc = code->arg;
+}
+
+static void trace_prejump_handler(scode *code)
+{
+    vm_trace.pc = code->arg;
+
+    NEXT_HANDLER(code);
+}
+
+static void trace_compile_handler(scode *trace_head)
+{
+    uint8_t *bytecode = vm_trace.bytecode;
+    size_t pc = vm_trace.pc;
+    size_t trace_size = 0;
+
+    const trace_opinfo *info = &trace_opcode_to_opinfo[bytecode[pc]];
+    scode *trace_tail = trace_head;
+    while (!info->is_final && !info->is_branch && trace_size < MAX_TRACE_LEN - 2) {
+        if (info->is_abs_jump) {
+            /* Absolute jumps need special care: we just jump continue parsing starting with the
+             * target pc of the instruction*/
+            uint64_t target = ARG_AT_PC(bytecode, pc);
+            pc = target;
+        } else {
+            /* For usual handlers we just set the handler and optionally skip argument bytes*/
+            trace_tail->handler = info->handler;
+
+            if (info->has_arg) {
+                uint64_t arg = ARG_AT_PC(bytecode, pc);
+                trace_tail->arg = arg;
+                pc += 2;
+            }
+            pc++;
+
+            trace_size++;
+            trace_tail++;
+        }
+
+        /* Get the next info and move the scode pointer */
+        info = &trace_opcode_to_opinfo[bytecode[pc]];
+    }
+
+    if (info->is_final) {
+        /* last instruction */
+        trace_tail->handler = info->handler;
+    } else if (info->is_branch) {
+        /* jump handler */
+
+        /* add a tail to skip the jump instruction - if the branch is not taken */
+        trace_tail->handler = trace_prejump_handler;
+        trace_tail->arg = pc + 3;
+
+        /* now, the jump handler itself */
+        trace_tail++;
+        trace_tail->handler = info->handler;
+        trace_tail->arg = ARG_AT_PC(bytecode, pc);
+    } else {
+        /* the trace is too long, add a tail handler */
+        trace_tail->handler = trace_tail_handler;
+        trace_tail->arg = pc;
+    }
+
+    /* now, run the chain */
+    trace_head->handler(trace_head);
+}
+
+static void vm_trace_reset(uint8_t *bytecode)
+{
+    vm_trace = (typeof(vm_trace)) {
+        .stack_top = vm_trace.stack,
+        .bytecode = bytecode,
+        .is_running = true
+    };
+    for (size_t trace_i = 0; trace_i < MAX_CODE_LEN; trace_i++ )
+        vm_trace.trace_cache[trace_i][0].handler = trace_compile_handler;
+}
+
+interpret_result vm_interpret_trace(uint8_t *bytecode)
+{
+    vm_trace_reset(bytecode);
+
+    if (!setjmp(vm_trace.buf)) {
+        while(vm_trace.is_running) {
+            scode *code = &vm_trace.trace_cache[vm_trace.pc][0];
+            code->handler(code);
+        }
+    }
+
+    return vm_trace.error;
+}
+
+uint64_t vm_trace_get_result(void)
+{
+    return vm_trace.result;
+}

--- a/pigletvm.h
+++ b/pigletvm.h
@@ -73,14 +73,14 @@ typedef enum {
     OP_NUMBER_OF_OPS
 } opcode;
 
-interpret_result vm_interpret(uint8_t *bytecode);
+interpret_result vm_rcache_interpret(uint8_t *bytecode);
 
-interpret_result vm_interpret_no_range_check(uint8_t *bytecode);
+interpret_result vm_rcache_interpret_no_range_check(uint8_t *bytecode);
 
-interpret_result vm_interpret_threaded(uint8_t *bytecode);
+interpret_result vm_rcache_interpret_threaded(uint8_t *bytecode);
 
-uint64_t vm_get_result(void);
+uint64_t vm_rcache_get_result(void);
 
-interpret_result vm_interpret_trace(uint8_t *bytecode);
+interpret_result vm_rcache_interpret_trace(uint8_t *bytecode);
 
-uint64_t vm_trace_get_result(void);
+uint64_t vm_rcache_trace_get_result(void);

--- a/pigletvm.h
+++ b/pigletvm.h
@@ -73,6 +73,20 @@ typedef enum {
     OP_NUMBER_OF_OPS
 } opcode;
 
+
+interpret_result vm_interpret(uint8_t *bytecode);
+
+interpret_result vm_interpret_no_range_check(uint8_t *bytecode);
+
+interpret_result vm_interpret_threaded(uint8_t *bytecode);
+
+uint64_t vm_get_result(void);
+
+interpret_result vm_interpret_trace(uint8_t *bytecode);
+
+uint64_t vm_trace_get_result(void);
+
+
 interpret_result vm_rcache_interpret(uint8_t *bytecode);
 
 interpret_result vm_rcache_interpret_no_range_check(uint8_t *bytecode);


### PR DESCRIPTION
The main idea of these optimizations is trying to cache the VM registers (ip, stack_top) and the top value of the stack in the actual machine's registers.

Additionally, these changes enable GCC to better optimize threaded code.