### PR TITLE
Update regexp interpreter 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -std=gnu11 -O3 -g
 
 INTERPRETERS = basic-switch immediate-arg stack-machine register-machine
 
-all: $(INTERPRETERS) pigletvm piglet-matcher
+all: $(INTERPRETERS) regexp-interpreter pigletvm piglet-matcher
 
 test: test-interpreters pigletvm-test piglet-matcher-test
 
@@ -11,6 +11,9 @@ test-interpreters: $(INTERPRETERS)
 	$(foreach interpr,$(INTERPRETERS),./$(interpr);)
 
 %: interpreter-%.c
+	$(CC) $(CFLAGS) $< -o $@
+	
+regexp-interpreter: interpreter-regexp.c
 	$(CC) $(CFLAGS) $< -o $@
 
 pigletvm: pigletvm.c pigletvm-rcache.c pigletvm-exec.c
@@ -28,6 +31,6 @@ piglet-matcher-test: piglet-matcher.c piglet-matcher-test.c
 	./piglet-matcher-test
 
 clean:
-	rm -vf $(INTERPRETERS) pigletvm pigletvm-test piglet-matcher piglet-matcher-test
+	rm -vf $(INTERPRETERS) regexp-interpreter pigletvm pigletvm-test piglet-matcher piglet-matcher-test
 
 .PHONY: all clean pigletvm-test piglet-matcher-test test-interpreters

--- a/interpreter-regexp.c
+++ b/interpreter-regexp.c
@@ -5,7 +5,7 @@
 #include <assert.h>
 
 typedef enum {
-    /* match a single char to an immediate argument from the string and advance ip and cp, or
+    /* match a single char to an immediate argument from the string and advance ip and sp, or
      * abort*/
     OP_CHAR,
     /* jump to and match either left expression or the right one, abort if nothing matches*/

--- a/interpreter-regexp.c
+++ b/interpreter-regexp.c
@@ -96,8 +96,8 @@ int main(int argc, char *argv[])
     {
         /* Match strings "abc" and "bc" against regexp "a?bc" */
         uint8_t code[] = {
-            OP_OR, 3, 7,
-            OP_CHAR, 'a', OP_JUMP, 7,
+            OP_OR, 3, 5,
+            OP_CHAR, 'a', 
             OP_CHAR, 'b', OP_CHAR, 'c',
             OP_MATCH
         };


### PR DESCRIPTION
A typo

Removed reduntant instruction "OP_JMP 7"

Add regexp-interpreter in Makefile.